### PR TITLE
Add `multi-draw-indirect` feature.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1254,6 +1254,12 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
     <tr class=row-continuation><td colspan=4>
         The maximum value for the arguments of {{GPUComputePassEncoder/dispatch(x, y, z)}}.
 
+    <tr><td><dfn>maxMultiDrawIndirectCount</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>1
+    <tr class=row-continuation><td colspan=4>
+        The maximum value for the `maxDrawCount` argument in
+        {{GPURenderEncoderBase/multiDrawIndirect()}} and {{GPURenderEncoderBase/multiDrawIndexedIndirect()}}.
+
 </table>
 
 Issue: Do we need to have a max per-pixel render target size?
@@ -1290,6 +1296,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxComputeWorkgroupInvocations;
     readonly attribute GPUExtent3D maxComputeWorkgroupSize;
     readonly attribute unsigned long maxComputePerDimensionDispatchSize;
+    readonly attribute unsigned long maxIndirectDrawCount;
 };
 </script>
 
@@ -6689,12 +6696,15 @@ interface mixin GPURenderEncoderBase {
                      optional GPUSignedOffset32 baseVertex = 0,
                      optional GPUSize32 firstInstance = 0);
 
-    undefined drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset,
-                     optional GPUSize32 maxDrawCount = 1,
+    undefined drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+    undefined drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+
+    undefined multiDrawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset,
+                     GPUSize32 maxDrawCount,
                      optional GPUBuffer drawCountBuffer = null,
                      optional GPUSize64 drawCountOffset = 0);
-    undefined drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset,
-                     optional GPUSize32 maxDrawCount = 1,
+    undefined multiDrawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset,
+                     GPUSize32 maxDrawCount,
                      optional GPUBuffer drawCountBuffer = null,
                      optional GPUSize64 drawCountOffset = 0);
 };
@@ -7216,12 +7226,12 @@ enum GPUStoreOp {
             </div>
         </div>
 
-    : <dfn>drawIndirect(indirectBuffer, indirectOffset, maxDrawCount, drawCountBuffer, drawCountOffset)</dfn>
+    : <dfn>drawIndirect(indirectBuffer, indirectOffset)</dfn>
     ::
         Draws primitives using parameters read from a {{GPUBuffer}}.
         See [[#rendering-operations]] for the detailed specification.
 
-        The <dfn dfn for=>indirect draw parameters</dfn> encoded in the |indirectBuffer| must be a tightly
+        The <dfn dfn for=>indirect draw parameters</dfn> encoded in the buffer must be a tightly
         packed block of **four 32-bit unsigned integer values (16 bytes total)**, given in the same
         order as the arguments for {{GPURenderEncoderBase/draw()}}. For example:
 
@@ -7238,13 +7248,6 @@ enum GPUStoreOp {
         non-zero `firstInstance` value will result in the {{GPURenderEncoderBase/drawIndirect()}} call being
         treated as a no-op.
 
-        If and only if the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled, [=indirect draw parameters=]
-        may be repeated with 16 byte stride, allowing multiple draws per call to {{GPURenderEncoderBase/drawIndirect()}}.
-        The actual number of draws is the minimum of |maxDrawCount| and the [=indirect draw count=] (if given).
-
-        The <dfn dfn for=>indirect draw count</dfn> encoded in the |drawCountBuffer| must be a **32-bit unsigned
-        integer** giving the number of draws to issue from the |indirectBuffer|.
-
         <div algorithm="GPURenderEncoderBase.drawIndirect">
             **Called on:** {{GPURenderEncoderBase}} this.
 
@@ -7252,9 +7255,6 @@ enum GPUStoreOp {
             <pre class=argumentdef for="GPURenderEncoderBase/drawIndirect(indirectBuffer, indirectOffset)">
                 |indirectBuffer|: Buffer containing the [=indirect draw parameters=].
                 |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
-                |maxDrawCount|: Maxumum number of draws or exact number of draws if |drawCountBuffer| is `null`.
-                |drawCountBuffer|: Buffer containing the [=indirect draw count=].
-                |drawCountOffset|: Offset in bytes into |drawCountBuffer| where the [=indirect draw count=] is located.
             </pre>
 
             **Returns:** {{undefined}}
@@ -7269,24 +7269,17 @@ enum GPUStoreOp {
                         - |indirectOffset| + sizeof([=indirect draw parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
                         - |indirectOffset| is a multiple of 4.
-                        - |maxDrawCount| = 1, unless the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled.
-                        - |drawCountBuffer| is `null`, unless the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled.
-                        - |drawCountBuffer| is [$valid to use with$] |this|.
-                        - |drawCountBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
-                        - |drawCountOffset| + sizeof([=indirect draw count=]) &le;
-                            |drawCountBuffer|.{{GPUBuffer/[[size]]}}.
-                        - |drawCountOffset| is a multiple of 4.
                     </div>
-                1. Add |indirectBuffer| and |drawCountBuffer| (if given) to the [=usage scope=] as [=internal usage/input=].
+                1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
             </div>
         </div>
 
-    : <dfn>drawIndexedIndirect(indirectBuffer, indirectOffset, maxDrawCount, drawCountBuffer, drawCountOffset)</dfn>
+    : <dfn>drawIndexedIndirect(indirectBuffer, indirectOffset)</dfn>
     ::
         Draws indexed primitives using parameters read from a {{GPUBuffer}}.
         See [[#rendering-operations]] for the detailed specification.
 
-        The <dfn dfn for=>indirect drawIndexed parameters</dfn> encoded in the |indirectBuffer| must be a
+        The <dfn dfn for=>indirect drawIndexed parameters</dfn> encoded in the buffer must be a
         tightly packed block of **five 32-bit unsigned integer values (20 bytes total)**, given in
         the same order as the arguments for {{GPURenderEncoderBase/drawIndexed()}}. For example:
 
@@ -7304,13 +7297,6 @@ enum GPUStoreOp {
         non-zero `firstInstance` value will result in the {{GPURenderEncoderBase/drawIndirect()}} call being
         treated as a no-op.
 
-        If and only if the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled, [=indirect draw parameters=]
-        may be repeated with 16 byte stride, allowing multiple draws per call to {{GPURenderEncoderBase/drawIndirect()}}.
-        The actual number of draws is the minimum of |maxDrawCount| and the [=indirect draw count=] (if given).
-
-        The <dfn dfn for=>indirect drawIndexed count</dfn> encoded in the |drawCountBuffer| must be a **32-bit unsigned
-        integer** giving the number of draws to issue from the |indirectBuffer|.
-
         <div algorithm="GPURenderEncoderBase.drawIndexedIndirect">
             **Called on:** {{GPURenderEncoderBase}} this.
 
@@ -7318,9 +7304,6 @@ enum GPUStoreOp {
             <pre class=argumentdef for="GPURenderEncoderBase/drawIndexedIndirect(indirectBuffer, indirectOffset)">
                 |indirectBuffer|: Buffer containing the [=indirect drawIndexed parameters=].
                 |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
-                |maxDrawCount|: Maxumum number of draws or exact number of draws if |drawCountBuffer| is `null`.
-                |drawCountBuffer|: Buffer containing the [=indirect drawIndexed count=].
-                |drawCountOffset|: Offset in bytes into |drawCountBuffer| where the [=indirect drawIndexed count=] is located.
             </pre>
 
             **Returns:** {{undefined}}
@@ -7335,11 +7318,132 @@ enum GPUStoreOp {
                         - |indirectOffset| + sizeof([=indirect drawIndexed parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
                         - |indirectOffset| is a multiple of 4.
-                        - |maxDrawCount| = 1, unless the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled.
+                    </div>
+                1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
+            </div>
+        </div>
+
+    : <dfn>multiDrawIndirect(indirectBuffer, indirectOffset, maxDrawCount, drawCountBuffer, drawCountOffset)</dfn>
+    ::
+        Draws primitives using an array of parameters read from a {{GPUBuffer}}.
+        See [[#rendering-operations]] for the detailed specification.
+
+        This method is defined if and only if the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled.
+
+        The <dfn dfn for=>indirect multiDraw parameters</dfn> encoded in the |indirectBuffer| must be zero or more
+        tightly packed blocks of **four 32-bit unsigned integer values (16 bytes total)**, given in the same
+        order as the arguments for {{GPURenderEncoderBase/draw()}}. For example:
+
+        <pre highlight="js">
+            let drawIndirectParameters = new Uint32Array(8);
+            // first draw
+            drawIndirectParameters[0] = vertexCount0;
+            drawIndirectParameters[1] = instanceCount0;
+            drawIndirectParameters[2] = firstVertex0;
+            drawIndirectParameters[3] = firstInstance0;
+            // second draw
+            drawIndirectParameters[4] = vertexCount1;
+            drawIndirectParameters[5] = instanceCount1;
+            drawIndirectParameters[6] = firstVertex1;
+            drawIndirectParameters[7] = firstInstance1;
+        </pre>
+
+        The <dfn dfn for=>indirect multiDraw count</dfn> encoded in the |drawCountBuffer| must be a **32-bit unsigned
+        integer** giving the number of draws to issue from the |indirectBuffer|.
+
+        <div algorithm="GPURenderEncoderBase.multiDrawIndirect">
+            **Called on:** {{GPURenderEncoderBase}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderEncoderBase/multiDrawIndirect(indirectBuffer, indirectOffset, maxDrawCount, drawCountBuffer, drawCountOffset)">
+                |indirectBuffer|: Buffer containing the [=indirect multiDraw parameters=].
+                |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
+                |maxDrawCount|: Maxumum number of draws or exact number of draws if |drawCountBuffer| is `null`.
+                |drawCountBuffer|: Buffer containing the [=indirect multiDraw count=].
+                |drawCountOffset|: Offset in bytes into |drawCountBuffer| where the [=indirect multiDraw count=] is located.
+            </pre>
+
+            **Returns:** {{undefined}}
+
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            <div class=device-timeline>
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                    <div class=validusage>
+                        - It is [$valid to draw$] with |this|.
+                        - |indirectBuffer| is [$valid to use with$] |this|.
+                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |indirectOffset| + sizeof([=indirect multiDraw parameters=]) &le;
+                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
+                        - |indirectOffset| is a multiple of 4.
+                        - |maxDrawCount| &le; limits.{{supported limits/maxMultiDrawIndirectCount}}.
                         - |drawCountBuffer| is `null`, unless the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled.
                         - |drawCountBuffer| is [$valid to use with$] |this|.
                         - |drawCountBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
-                        - |drawCountOffset| + sizeof([=indirect drawIndexed count=]) &le;
+                        - |drawCountOffset| + sizeof([=indirect multiDraw count=]) &le;
+                            |drawCountBuffer|.{{GPUBuffer/[[size]]}}.
+                        - |drawCountOffset| is a multiple of 4.
+                    </div>
+                1. Add |indirectBuffer| and |drawCountBuffer| (if given) to the [=usage scope=] as [=internal usage/input=].
+            </div>
+        </div>
+
+    : <dfn>multiDrawIndexedIndirect(indirectBuffer, indirectOffset, maxDrawCount, drawCountBuffer, drawCountOffset)</dfn>
+    ::
+        Draws indexed primitives using an array of parameters read from a {{GPUBuffer}}.
+        See [[#rendering-operations]] for the detailed specification.
+
+        The <dfn dfn for=>indirect multiDrawIndexed parameters</dfn> encoded in the |indirectBuffer| must be zero or more
+        tightly packed blocks of **five 32-bit unsigned integer values (20 bytes total)**, given in
+        the same order as the arguments for {{GPURenderEncoderBase/drawIndexed()}}. For example:
+
+        <pre highlight="js">
+            let drawIndexedIndirectParameters = new Uint32Array(10);
+            // first draw
+            drawIndexedIndirectParameters[0] = indexCount0;
+            drawIndexedIndirectParameters[1] = instanceCount0;
+            drawIndexedIndirectParameters[2] = firstIndex0;
+            drawIndexedIndirectParameters[3] = baseVertex0;
+            drawIndexedIndirectParameters[4] = firstInstance0;
+            // second draw
+            drawIndexedIndirectParameters[5] = indexCount1;
+            drawIndexedIndirectParameters[6] = instanceCount1;
+            drawIndexedIndirectParameters[7] = firstIndex1;
+            drawIndexedIndirectParameters[8] = baseVertex1;
+            drawIndexedIndirectParameters[9] = firstInstance1;
+        </pre>
+
+        The <dfn dfn for=>indirect multiDrawIndexed count</dfn> encoded in the |drawCountBuffer| must be a **32-bit unsigned
+        integer** giving the number of draws to issue from the |indirectBuffer|.
+
+        <div algorithm="GPURenderEncoderBase.multiDrawIndexedIndirect">
+            **Called on:** {{GPURenderEncoderBase}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderEncoderBase/multiDrawIndexedIndirect(indirectBuffer, indirectOffset, maxDrawCount, drawCountBuffer, drawCountOffset)">
+                |indirectBuffer|: Buffer containing the [=indirect multiDrawIndexed parameters=].
+                |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
+                |maxDrawCount|: Maxumum number of draws or exact number of draws if |drawCountBuffer| is `null`.
+                |drawCountBuffer|: Buffer containing the [=indirect multiDrawIndexed count=].
+                |drawCountOffset|: Offset in bytes into |drawCountBuffer| where the [=indirect multiDrawIndexed count=] is located.
+            </pre>
+
+            **Returns:** {{undefined}}
+
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            <div class=device-timeline>
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                    <div class=validusage>
+                        - It is [$valid to draw indexed$] with |this|.
+                        - |indirectBuffer| is [$valid to use with$] |this|.
+                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |indirectOffset| + sizeof([=indirect multiDrawIndexed parameters=]) &le;
+                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
+                        - |indirectOffset| is a multiple of 4.
+                        - |maxDrawCount| &le; limits.{{supported limits/maxMultiDrawIndirectCount}}.
+                        - |drawCountBuffer| is `null`, unless the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled.
+                        - |drawCountBuffer| is [$valid to use with$] |this|.
+                        - |drawCountBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |drawCountOffset| + sizeof([=indirect multiDrawIndexed count=]) &le;
                             |drawCountBuffer|.{{GPUBuffer/[[size]]}}.
                         - |drawCountOffset| is a multiple of 4.
                     </div>
@@ -7347,10 +7451,6 @@ enum GPUStoreOp {
             </div>
         </div>
 </dl>
-
-Note: The ability to set a `firstInstance` for indirect draw calls is initially disabled to expand
-the hardware that supports WebGPU. It is likely to be added as a feature in the future along with
-other new indirect drawing features.
 
 <div algorithm>
     To determine if it's <dfn abstract-op>valid to draw</dfn> with {{GPURenderEncoderBase}} |encoder|
@@ -9292,26 +9392,20 @@ The following enums are supported if and only if the {{GPUFeatureName/"depth32fl
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>multi-draw-indirect</dfn> ## {#multi-draw-indirect}
 
-Allows {{GPURenderEncoderBase/drawIndirect()}} and {{GPURenderEncoderBase/drawIndexedIndirect()}} to
-operate on arrays of [=indirect draw parameters=] and [=indirect drawIndexed parameters=] respectively
-and allows `firstInstance` to be greater than 0.
+Allows the use of the {{GPURenderEncoderBase/multiDrawIndirect()}} and
+{{GPURenderEncoderBase/multiDrawIndexedIndirect()}} methods and removes the zero value restriction on
+`firstInstance` in [=indirect draw parameters=] and [=indirect drawIndexed parameters=].
 
-**Feature Function Arguments**
+**Feature Methods**
 
-The following optional function arguments are supported if and only if the
-{{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled.
+The following methods are supported if and only if the {{GPUFeatureName/"multi-draw-indirect"}}
+[=feature=] is enabled.
 
 <dl>
-    : {{GPURenderEncoderBase/drawIndirect()}}
+    : {{GPURenderEncoderBase}}
     ::
-        * <l>{{GPURenderEncoderBase/drawIndirect(indirectBuffer, indirectOffset)/maxDrawCount}}</l>
-        * <l>{{GPURenderEncoderBase/drawIndirect(indirectBuffer, indirectOffset)/drawCountBuffer}}</l>
-        * <l>{{GPURenderEncoderBase/drawIndirect(indirectBuffer, indirectOffset)/drawCountOffset}}</l>
-    : {{GPURenderEncoderBase/drawIndexedIndirect()}}
-    ::
-        * <l>{{GPURenderEncoderBase/drawIndexedIndirect(indirectBuffer, indirectOffset)/maxDrawCount}}</l>
-        * <l>{{GPURenderEncoderBase/drawIndexedIndirect(indirectBuffer, indirectOffset)/drawCountBuffer}}</l>
-        * <l>{{GPURenderEncoderBase/drawIndexedIndirect(indirectBuffer, indirectOffset)/drawCountOffset}}</l>
+        * {{GPURenderEncoderBase/multiDrawIndirect()}}
+        * {{GPURenderEncoderBase/multiDrawIndexedIndirect()}}
 </dl>
 
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1734,6 +1734,7 @@ enum GPUFeatureName {
     "depth-clamping",
     "depth24unorm-stencil8",
     "depth32float-stencil8",
+    "multi-draw-indirect",
     "pipeline-statistics-query",
     "texture-compression-bc",
     "timestamp-query",
@@ -6688,8 +6689,14 @@ interface mixin GPURenderEncoderBase {
                      optional GPUSignedOffset32 baseVertex = 0,
                      optional GPUSize32 firstInstance = 0);
 
-    undefined drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
-    undefined drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+    undefined drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset,
+                     optional GPUSize32 maxDrawCount = 1,
+                     optional GPUBuffer drawCountBuffer = null,
+                     optional GPUSize64 drawCountOffset = 0);
+    undefined drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset,
+                     optional GPUSize32 maxDrawCount = 1,
+                     optional GPUBuffer drawCountBuffer = null,
+                     optional GPUSize64 drawCountOffset = 0);
 };
 
 [Exposed=(Window, DedicatedWorker)]
@@ -7209,12 +7216,12 @@ enum GPUStoreOp {
             </div>
         </div>
 
-    : <dfn>drawIndirect(indirectBuffer, indirectOffset)</dfn>
+    : <dfn>drawIndirect(indirectBuffer, indirectOffset, maxDrawCount, drawCountBuffer, drawCountOffset)</dfn>
     ::
         Draws primitives using parameters read from a {{GPUBuffer}}.
         See [[#rendering-operations]] for the detailed specification.
 
-        The <dfn dfn for=>indirect draw parameters</dfn> encoded in the buffer must be a tightly
+        The <dfn dfn for=>indirect draw parameters</dfn> encoded in the |indirectBuffer| must be a tightly
         packed block of **four 32-bit unsigned integer values (16 bytes total)**, given in the same
         order as the arguments for {{GPURenderEncoderBase/draw()}}. For example:
 
@@ -7223,11 +7230,20 @@ enum GPUStoreOp {
             drawIndirectParameters[0] = vertexCount;
             drawIndirectParameters[1] = instanceCount;
             drawIndirectParameters[2] = firstVertex;
-            drawIndirectParameters[3] = 0; // firstInstance. Must be 0.
+            drawIndirectParameters[3] = firstInstance;
         </pre>
 
-        The value corresponding to `firstInstance` is reserved for future use and must be zero. If
-        it is not zero the {{GPURenderEncoderBase/drawIndirect()}} call will be treated as a no-op.
+        The value cooresponding to `firstInstance` must be 0, unless the {{GPUFeatureName/"multi-draw-indirect"}}
+        [=feature=] is enabled.  If the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is not enabled a
+        non-zero `firstInstance` value will result in the {{GPURenderEncoderBase/drawIndirect()}} call being
+        treated as a no-op.
+
+        If and only if the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled, [=indirect draw parameters=]
+        may be repeated with 16 byte stride, allowing multiple draws per call to {{GPURenderEncoderBase/drawIndirect()}}.
+        The actual number of draws is the minimum of |maxDrawCount| and the [=indirect draw count=] (if given).
+
+        The <dfn dfn for=>indirect draw count</dfn> encoded in the |drawCountBuffer| must be a **32-bit unsigned
+        integer** giving the number of draws to issue from the |indirectBuffer|.
 
         <div algorithm="GPURenderEncoderBase.drawIndirect">
             **Called on:** {{GPURenderEncoderBase}} this.
@@ -7236,6 +7252,9 @@ enum GPUStoreOp {
             <pre class=argumentdef for="GPURenderEncoderBase/drawIndirect(indirectBuffer, indirectOffset)">
                 |indirectBuffer|: Buffer containing the [=indirect draw parameters=].
                 |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
+                |maxDrawCount|: Maxumum number of draws or exact number of draws if |drawCountBuffer| is `null`.
+                |drawCountBuffer|: Buffer containing the [=indirect draw count=].
+                |drawCountOffset|: Offset in bytes into |drawCountBuffer| where the [=indirect draw count=] is located.
             </pre>
 
             **Returns:** {{undefined}}
@@ -7250,17 +7269,24 @@ enum GPUStoreOp {
                         - |indirectOffset| + sizeof([=indirect draw parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
                         - |indirectOffset| is a multiple of 4.
+                        - |maxDrawCount| = 1, unless the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled.
+                        - |drawCountBuffer| is `null`, unless the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled.
+                        - |drawCountBuffer| is [$valid to use with$] |this|.
+                        - |drawCountBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |drawCountOffset| + sizeof([=indirect draw count=]) &le;
+                            |drawCountBuffer|.{{GPUBuffer/[[size]]}}.
+                        - |drawCountOffset| is a multiple of 4.
                     </div>
-                1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
+                1. Add |indirectBuffer| and |drawCountBuffer| (if given) to the [=usage scope=] as [=internal usage/input=].
             </div>
         </div>
 
-    : <dfn>drawIndexedIndirect(indirectBuffer, indirectOffset)</dfn>
+    : <dfn>drawIndexedIndirect(indirectBuffer, indirectOffset, maxDrawCount, drawCountBuffer, drawCountOffset)</dfn>
     ::
         Draws indexed primitives using parameters read from a {{GPUBuffer}}.
         See [[#rendering-operations]] for the detailed specification.
 
-        The <dfn dfn for=>indirect drawIndexed parameters</dfn> encoded in the buffer must be a
+        The <dfn dfn for=>indirect drawIndexed parameters</dfn> encoded in the |indirectBuffer| must be a
         tightly packed block of **five 32-bit unsigned integer values (20 bytes total)**, given in
         the same order as the arguments for {{GPURenderEncoderBase/drawIndexed()}}. For example:
 
@@ -7273,9 +7299,17 @@ enum GPUStoreOp {
             drawIndexedIndirectParameters[4] = 0; // firstInstance. Must be 0.
         </pre>
 
-        The value corresponding to `firstInstance` is reserved for future use and must be zero. If
-        it is not zero the {{GPURenderEncoderBase/drawIndexedIndirect()}} call will be treated as a
-        no-op.
+        The value cooresponding to `firstInstance` must be 0, unless the {{GPUFeatureName/"multi-draw-indirect"}}
+        [=feature=] is enabled.  If the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is not enabled a
+        non-zero `firstInstance` value will result in the {{GPURenderEncoderBase/drawIndirect()}} call being
+        treated as a no-op.
+
+        If and only if the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled, [=indirect draw parameters=]
+        may be repeated with 16 byte stride, allowing multiple draws per call to {{GPURenderEncoderBase/drawIndirect()}}.
+        The actual number of draws is the minimum of |maxDrawCount| and the [=indirect draw count=] (if given).
+
+        The <dfn dfn for=>indirect drawIndexed count</dfn> encoded in the |drawCountBuffer| must be a **32-bit unsigned
+        integer** giving the number of draws to issue from the |indirectBuffer|.
 
         <div algorithm="GPURenderEncoderBase.drawIndexedIndirect">
             **Called on:** {{GPURenderEncoderBase}} this.
@@ -7284,6 +7318,9 @@ enum GPUStoreOp {
             <pre class=argumentdef for="GPURenderEncoderBase/drawIndexedIndirect(indirectBuffer, indirectOffset)">
                 |indirectBuffer|: Buffer containing the [=indirect drawIndexed parameters=].
                 |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
+                |maxDrawCount|: Maxumum number of draws or exact number of draws if |drawCountBuffer| is `null`.
+                |drawCountBuffer|: Buffer containing the [=indirect drawIndexed count=].
+                |drawCountOffset|: Offset in bytes into |drawCountBuffer| where the [=indirect drawIndexed count=] is located.
             </pre>
 
             **Returns:** {{undefined}}
@@ -7298,8 +7335,15 @@ enum GPUStoreOp {
                         - |indirectOffset| + sizeof([=indirect drawIndexed parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
                         - |indirectOffset| is a multiple of 4.
+                        - |maxDrawCount| = 1, unless the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled.
+                        - |drawCountBuffer| is `null`, unless the {{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled.
+                        - |drawCountBuffer| is [$valid to use with$] |this|.
+                        - |drawCountBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |drawCountOffset| + sizeof([=indirect drawIndexed count=]) &le;
+                            |drawCountBuffer|.{{GPUBuffer/[[size]]}}.
+                        - |drawCountOffset| is a multiple of 4.
                     </div>
-                1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
+                1. Add |indirectBuffer| and |drawCountBuffer| (if given) to the [=usage scope=] as [=internal usage/input=].
             </div>
         </div>
 </dl>
@@ -9245,6 +9289,31 @@ The following enums are supported if and only if the {{GPUFeatureName/"depth32fl
     ::
         * {{GPUTextureFormat/"depth32float-stencil8"}}
 </dl>
+
+## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>multi-draw-indirect</dfn> ## {#multi-draw-indirect}
+
+Allows {{GPURenderEncoderBase/drawIndirect()}} and {{GPURenderEncoderBase/drawIndexedIndirect()}} to
+operate on arrays of [=indirect draw parameters=] and [=indirect drawIndexed parameters=] respectively
+and allows `firstInstance` to be greater than 0.
+
+**Feature Function Arguments**
+
+The following optional function arguments are supported if and only if the
+{{GPUFeatureName/"multi-draw-indirect"}} [=feature=] is enabled.
+
+<dl>
+    : {{GPURenderEncoderBase/drawIndirect()}}
+    ::
+        * <l>{{GPURenderEncoderBase/drawIndirect(indirectBuffer, indirectOffset)/maxDrawCount}}</l>
+        * <l>{{GPURenderEncoderBase/drawIndirect(indirectBuffer, indirectOffset)/drawCountBuffer}}</l>
+        * <l>{{GPURenderEncoderBase/drawIndirect(indirectBuffer, indirectOffset)/drawCountOffset}}</l>
+    : {{GPURenderEncoderBase/drawIndexedIndirect()}}
+    ::
+        * <l>{{GPURenderEncoderBase/drawIndexedIndirect(indirectBuffer, indirectOffset)/maxDrawCount}}</l>
+        * <l>{{GPURenderEncoderBase/drawIndexedIndirect(indirectBuffer, indirectOffset)/drawCountBuffer}}</l>
+        * <l>{{GPURenderEncoderBase/drawIndexedIndirect(indirectBuffer, indirectOffset)/drawCountOffset}}</l>
+</dl>
+
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>pipeline-statistics-query</dfn> ## {#pipeline-statistics-query}
 


### PR DESCRIPTION
NOTE: This is a PR for internal review only, DO NOT MERGE.


The current spec is available at: [https://gpuweb.github.io/gpuweb/](https://gpuweb.github.io/gpuweb/)
The spec in this PR in it's built form has been uploaded to Slack.

-------------------------------------

Indirect drawing with multiple indirect drawing commands is a common technique (currently available in WebGL as an extension) for drawing complex scenes that would otherwise be infeasible due to either an excessive number of CPU issued draw calls or scene complexity that cannot be built by the CPU alone.  This is done by:

* Executing multiple draws with a single API call.
* Allowing the GPU to generate both geometry and the draws necessary to render it.
* Culling out unnecessary draw calls on the GPU in more complex scenes than CPU culling could achieve.

This PR addresses adding a `multi-draw-indirect` feature.  In particular it addresses adding:

* Optional `maxDrawCount` argument to `drawIndirect` and `drawIndexedIndirect`.
    * Specifies the number of indirect draw parameter groups in the `indirectBuffer`.
    * Allows submitting multiple draws with a single API call.
    * Clamps the value in `drawCountBuffer`.
    * Use cases:
        * GPU derived scene data
        * GPU based culling
        * GPU based LOD
        * Efficient execution of complex scenes with a large number of draws
* Optional `drawCountBuffer`, and `drawCountOffset` arguments to `drawIndirect` and `drawIndexedIndirect`.
    * Location in GPU memory to lookup the number of indirect draw parameter groups to draw in `indirectBuffer`.
    * Allows the GPU to compute how many draw calls to issue.
    * Use cases:
        * GPU based culling
        * GPU based LOD
        * One-to-many GPU derived scene objects
* Non-zero `firstInstance` for `drawIndirect` and `drawIndexedIndirect`
    * This is the only available per draw input, without rebinds, that is readable in the shader.
    * Use cases:
        * Select instance stride vertex data
        * Index into per object or per draw data in storage buffers
        * Multi material, single API call, rendering

The signatures for these functions will become:
```
drawIndirect(indirectBuffer, indirectOffset, maxDrawCount, drawCountBuffer, drawCountOffset)
drawIndexedIndirect(indirectBuffer, indirectOffset, maxDrawCount, drawCountBuffer, drawCountOffset)
```

The `indirectBuffer` will become a tightly packed array of the existing binary layout.  The 0 value restriction on the `firstInstance` element of the indirect draw parameter buffer will be relaxed to any non-negative integer.


# Compatibility

The required backend features to implement `multi-draw-indirect` are available on:

* All supported Apple devices
* All DX12 devices
* All Vulkan capable desktops (with up to date drivers)
* 30% of Android devices

See the sections below for details.


## Vulkan

### Multi-Draw

Requires the 0 or 1 restriction on the `drawCount` argument of `vkCmdDrawIndirect` and `vkCmdDrawIndexIndirect` to be relaxed to any non-negative integer.  This requires the `multiDrawIndirect` feature which is supported on:

* 99% of desktop GPUs
* 63% of Android devices

_NOTE: The `stride` argument will always be set for tight packing, in order to maintain compatibility with DX12._


### Draw Count

Requires the `vkCmdDrawIndirectCount` and `vkCmdDrawIndexedIndirectCount` functions which are provided by either the `drawIndirectCount` feature of Vulkan 1.2 or one of the following extensions:

* `VK_AMD_draw_indirect_count`
* `VK_KHR_draw_indirect_count`

Because `drawIndirectCount` was introduced in driver updates the statistics at [https://vulkan.gpuinfo.org](https://vulkan.gpuinfo.org) cannot be relied upon.  The following is based on the oldest card that supports `drawIndirectCount` from each manufacturer, if newer cards dropped support for `drawIndirectCount` that is not captured here.

* Intel integrated cards (that support Vulkan) support `drawIndirectCount`.
* NVIDIA cards going back to Kepler support `drawIndirectCount`.
* AMD cards going back to the HD 8000 series support `drawIndirectCount`.

For Android:

* `drawIndirectCount` is supported on 100% of devices that support Vulkan 1.2.
* `drawIndirectCount` is supported, as an extension, on 28% of devices that do not support Vulkan 1.2.


### Non-zero `firstInstance`

Requires the `firstInstance` property of the `VkDrawIndirectCommand` and `VkDrawIndexedIndirectCommand` to be non-zero.  This requires the `drawIndirectFirstInstance` feature which is supported on:

* 99% of desktop GPUs
* 64% of Android devices


## DX12

All required features are core to DX12.


### Multi-Draw

Uses `ExecuteIndirect` where the `MaxCommandCount` argument is greater than 1 and the `pArgumentBuffer` argument points to a GPU buffer containing an array of `D3D12_DRAW_ARGUMENTS` or `D3D12_DRAW_INDEXED_ARGUMENTS`.

_NOTE: The binary layout of these structs are compatible with Vulkan._


### Draw Count

Uses `ExecuteIndirect` where the `pCountBuffer` argument is not NULL.  


### Non-zero `firstInstance`

This is the `StartInstanceLocation` of the `D3D12_DRAW_ARGUMENTS` or `D3D12_DRAW_INDEXED_ARGUMENTS` structures.  Has native support for values greater than 0.


## Metal

### Multi-Draw

Can be emulated with Indirect Command Buffers (ICBs) and an extra compute shader invocation to translate from the Vulkan-like indirect draw buffer to an ICB.

Requires

* iOS 12.0+
* macOS 10.14+

Supported on all versions which are still maintained.


### Non-zero `firstInstance`

Natively supported with the `baseInstance` argument.


### Draw Count

Don't record commands past this count in the ICB and use `optimizedIndirectCommandBuffer`.

Requires

* iOS 12.0+
* macOS 10.14+

Supported on all versions which are still maintained.
